### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # HotNews MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@wopal/mcp-server-hotnews)](https://smithery.ai/server/@wopal/mcp-server-hotnews)
+
 A Model Context Protocol (MCP) server that provides real-time hot trending topics from major Chinese social platforms and news sites.
 
 ## Features
@@ -33,6 +35,14 @@ A Model Context Protocol (MCP) server that provides real-time hot trending topic
   - `get_hot_news([1,2,3,4])` : Get hot lists from zhihuHot, 36Kr, Baidu, and Bilibili`
 
 ## Installation
+
+### Installing via Smithery
+
+To install HotNews Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@wopal/mcp-server-hotnews):
+
+```bash
+npx -y @smithery/cli install @wopal/mcp-server-hotnews --client claude
+```
 
 ### NPX
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,13 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required: []
+    properties: {}
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'node', args: ['dist/index.js'], env: {} })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@wopal/mcp-server-hotnews?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂